### PR TITLE
Implement basic round logic and collisions

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -28,3 +28,8 @@ pub struct Projectile {
     pub owner: usize,
     pub damage: f32,
 }
+
+#[derive(Component)]
+pub struct Lifetime {
+    pub time_left: f32,
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,6 @@
+use bevy::prelude::*;
+
+#[derive(Event)]
+pub struct PlayerKilled {
+    pub winner: usize,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,11 @@ use bevy::prelude::*;
 
 mod components;
 mod systems;
+mod resources;
+mod events;
+
+use events::PlayerKilled;
+use resources::RoundManager;
 
 fn main() {
     App::new()
@@ -13,6 +18,8 @@ fn main() {
             }),
             ..default()
         }))
+        .init_resource::<RoundManager>()
+        .add_event::<PlayerKilled>()
         .add_systems(Startup, systems::setup)
         .add_systems(
             Update,
@@ -20,6 +27,9 @@ fn main() {
                 systems::player_input,
                 systems::apply_velocity,
                 systems::projectile_cleanup,
+                systems::lifetime_system,
+                systems::projectile_player_collision,
+                systems::round_manager,
             ),
         )
         .run();

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,0 +1,18 @@
+use bevy::prelude::*;
+
+#[derive(Resource)]
+pub struct RoundManager {
+    pub p1_score: u32,
+    pub p2_score: u32,
+    pub rounds_to_win: u32,
+}
+
+impl Default for RoundManager {
+    fn default() -> Self {
+        Self {
+            p1_score: 0,
+            p2_score: 0,
+            rounds_to_win: 3,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Lifetime, events and resources for round tracking
- spawn projectiles with lifetime component
- detect projectile collisions and manage player health
- manage rounds and scores with RoundManager

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b801508b48323b01f6d31d12fbd14