### PR TITLE
Add poison card with status effect

### DIFF
--- a/src/cards.rs
+++ b/src/cards.rs
@@ -6,6 +6,7 @@ pub enum CardId {
     Power,
     Speed,
     Jump,
+    Poison,
 }
 
 #[derive(Clone, Copy)]
@@ -31,6 +32,11 @@ pub const ALL_CARDS: &[Card] = &[
         name: "Jump",
         description: "Increase jump force",
     },
+    Card {
+        id: CardId::Poison,
+        name: "Poison",
+        description: "Projectiles apply poison",
+    },
 ];
 
 pub fn random_choices(n: usize) -> Vec<Card> {
@@ -45,5 +51,6 @@ pub fn apply(card: CardId, stats: &mut Stats) {
         CardId::Power => stats.damage *= 1.2,
         CardId::Speed => stats.move_speed *= 1.2,
         CardId::Jump => stats.jump_force *= 1.2,
+        CardId::Poison => stats.poison_damage += 5.0,
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -19,8 +19,8 @@ pub struct Stats {
     pub projectile_speed: f32,
     pub shot_cooldown: f32,
     pub cooldown_timer: f32,
+    pub poison_damage: f32,
 }
-
 
 #[derive(Component)]
 pub struct Projectile {
@@ -36,4 +36,16 @@ pub struct Lifetime {
 #[derive(Component, Default)]
 pub struct Inventory {
     pub cards: Vec<crate::cards::CardId>,
+}
+
+#[derive(Component)]
+pub struct PoisonEffect {
+    pub damage_per_second: f32,
+    pub duration: f32,
+}
+
+#[derive(Component)]
+pub struct Poisoned {
+    pub damage_per_second: f32,
+    pub timer: Timer,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
                 systems::update_cooldowns,
                 systems::projectile_cleanup,
                 systems::lifetime_system,
+                systems::poison_damage_system,
                 systems::projectile_player_collision,
                 systems::round_manager,
                 systems::card_input_system,


### PR DESCRIPTION
## Summary
- implement poison upgrade and effects
- apply new card to players and projectiles
- process poison damage over time
- include new system in main schedule

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686c8437f6508323aa508897e01b9916