### PR TITLE
Implement slow effect card

### DIFF
--- a/src/cards.rs
+++ b/src/cards.rs
@@ -7,6 +7,7 @@ pub enum CardId {
     Speed,
     Jump,
     Poison,
+    Slow,
 }
 
 #[derive(Clone, Copy)]
@@ -37,6 +38,11 @@ pub const ALL_CARDS: &[Card] = &[
         name: "Poison",
         description: "Projectiles apply poison",
     },
+    Card {
+        id: CardId::Slow,
+        name: "Frost",
+        description: "Projectiles slow enemies",
+    },
 ];
 
 pub fn random_choices(n: usize) -> Vec<Card> {
@@ -52,5 +58,6 @@ pub fn apply(card: CardId, stats: &mut Stats) {
         CardId::Speed => stats.move_speed *= 1.2,
         CardId::Jump => stats.jump_force *= 1.2,
         CardId::Poison => stats.poison_damage += 5.0,
+        CardId::Slow => stats.slow_amount = 0.5,
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -20,6 +20,7 @@ pub struct Stats {
     pub shot_cooldown: f32,
     pub cooldown_timer: f32,
     pub poison_damage: f32,
+    pub slow_amount: f32,
 }
 
 #[derive(Component)]
@@ -47,5 +48,17 @@ pub struct PoisonEffect {
 #[derive(Component)]
 pub struct Poisoned {
     pub damage_per_second: f32,
+    pub timer: Timer,
+}
+
+#[derive(Component)]
+pub struct SlowEffect {
+    pub amount: f32,
+    pub duration: f32,
+}
+
+#[derive(Component)]
+pub struct Slowed {
+    pub amount: f32,
     pub timer: Timer,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
                 systems::projectile_cleanup,
                 systems::lifetime_system,
                 systems::poison_damage_system,
+                systems::slow_system,
                 systems::projectile_player_collision,
                 systems::round_manager,
                 systems::card_input_system,


### PR DESCRIPTION
## Summary
- add `SlowEffect` and `Slowed` components
- add new `Frost` card that applies slowdown
- spawn slow effect projectiles and apply `Slowed` status
- tick slowdown with new system
- display slow state in movement logic

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686c85f6f3b08323a736c6ccd2ffaba2