### PR TITLE
Fix jump key binding

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -31,7 +31,7 @@ To build this game, we will use a modern Rust-based game development stack. Belo
 
 - **Input Handling:** Bevy’s input system will let us manage keyboard and gamepad controls. We will support two players:
 
-  - **Player 1:** Keyboard (WASD for movement, space to jump, maybe arrow keys to aim if using aim, etc.) or first gamepad.
+  - **Player 1:** Keyboard (WASD for movement, **Space** to jump, **Left Ctrl** to shoot, Q/E to aim) or first gamepad.
   - **Player 2:** Second gamepad (or an alternative key scheme). Bevy assigns unique IDs to each connected gamepad, which we can use to map inputs to specific players. This makes local multiplayer input handling straightforward – we’ll read gamepad events and route them to the appropriate player entity. We will likely create an input mapping resource or use an input plugin (like `leafwing_input_manager`) to define actions (move, jump, shoot, block) and bind them for each player. Ensuring both keyboard and controller can be used will make testing easier (solo developer can control both players with one on keyboard, one on controller).
 
 - **Development Tools & Other Libraries:** As a newcomer to the ecosystem, it’s wise to leverage some helper tools:

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -22,7 +22,7 @@ pub fn setup(mut commands: Commands) {
     ));
     commands.spawn((
         SpriteBundle {
-            transform: Transform::from_xyz(-100.0, 0.0, 0.0),
+            transform: Transform::from_xyz(-100.0, 15.0, 0.0),
             sprite: Sprite {
                 color: Color::BLUE,
                 custom_size: Some(Vec2::splat(30.0)),
@@ -54,7 +54,7 @@ pub fn setup(mut commands: Commands) {
     ));
     commands.spawn((
         SpriteBundle {
-            transform: Transform::from_xyz(100.0, 0.0, 0.0),
+            transform: Transform::from_xyz(100.0, 15.0, 0.0),
             sprite: Sprite {
                 color: Color::RED,
                 custom_size: Some(Vec2::splat(30.0)),
@@ -113,10 +113,10 @@ pub fn player_input(
                 if keyboard.pressed(KeyCode::E) {
                     stats.aim_angle -= 0.05;
                 }
-                if keyboard.just_pressed(KeyCode::W) && transform.translation.y <= 0.0 {
+                if keyboard.just_pressed(KeyCode::Space) && transform.translation.y <= 16.0 {
                     velocity.linvel.y = stats.jump_force;
                 }
-                if keyboard.pressed(KeyCode::Space) && stats.cooldown_timer <= 0.0 {
+                if keyboard.pressed(KeyCode::ControlLeft) && stats.cooldown_timer <= 0.0 {
                     spawn_projectile(&mut commands, player.id, &*stats, transform);
                     stats.cooldown_timer = stats.shot_cooldown;
                 }
@@ -134,7 +134,7 @@ pub fn player_input(
                 if keyboard.pressed(KeyCode::Period) {
                     stats.aim_angle -= 0.05;
                 }
-                if keyboard.just_pressed(KeyCode::Up) && transform.translation.y <= 0.0 {
+                if keyboard.just_pressed(KeyCode::Up) && transform.translation.y <= 16.0 {
                     velocity.linvel.y = stats.jump_force;
                 }
                 if keyboard.pressed(KeyCode::Return) && stats.cooldown_timer <= 0.0 {


### PR DESCRIPTION
## Summary
- spawn players slightly above ground
- rebind jump to Space and shooting to Left Ctrl
- document updated key bindings

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686cb6829c38832385f82e285a7ff57d