### PR TITLE
Implement UI states for card selection and game over

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ fn main() {
         .add_state::<GameState>()
         .add_event::<PlayerKilled>()
         .add_systems(Startup, (systems::setup, systems::setup_hud))
+        .add_systems(OnEnter(GameState::CardSelection), systems::setup_card_ui)
+        .add_systems(OnExit(GameState::CardSelection), systems::cleanup_card_ui)
+        .add_systems(OnEnter(GameState::GameOver), systems::setup_game_over)
+        .add_systems(OnExit(GameState::GameOver), systems::cleanup_game_over)
         .add_systems(
             Update,
             (
@@ -56,9 +60,18 @@ fn main() {
                 systems::slow_system,
                 systems::projectile_player_collision,
                 systems::round_manager,
-                systems::card_input_system,
                 systems::update_hud,
-            ),
+            )
+                .run_if(in_state(GameState::InGame)),
+        )
+        .add_systems(
+            Update,
+            (systems::card_input_system, systems::card_click_system)
+                .run_if(in_state(GameState::CardSelection)),
+        )
+        .add_systems(
+            Update,
+            (systems::game_over_input).run_if(in_state(GameState::GameOver)),
         )
         .run();
 }

--- a/src/systems/card_selection.rs
+++ b/src/systems/card_selection.rs
@@ -1,0 +1,100 @@
+use bevy::prelude::*;
+
+use crate::cards;
+use crate::components::{Inventory, Player, Stats};
+use crate::resources::CardSelection;
+use crate::states::GameState;
+
+#[derive(Component)]
+pub struct CardUiRoot;
+
+#[derive(Component)]
+pub struct CardButton {
+    pub index: usize,
+}
+
+pub fn setup_card_ui(mut commands: Commands, selection: Res<CardSelection>) {
+    // root full screen node
+    let root = commands
+        .spawn((
+            NodeBundle {
+                style: Style {
+                    width: Val::Percent(100.0),
+                    height: Val::Percent(100.0),
+                    justify_content: JustifyContent::SpaceEvenly,
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                background_color: Color::rgba(0.0, 0.0, 0.0, 0.7).into(),
+                ..default()
+            },
+            CardUiRoot,
+        ))
+        .id();
+
+    for (i, card) in selection.choices.iter().enumerate() {
+        commands.entity(root).with_children(|parent| {
+            parent
+                .spawn((
+                    ButtonBundle {
+                        style: Style {
+                            width: Val::Px(180.0),
+                            height: Val::Px(120.0),
+                            flex_direction: FlexDirection::Column,
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            margin: UiRect::all(Val::Px(5.0)),
+                            ..default()
+                        },
+                        background_color: Color::DARK_GRAY.into(),
+                        ..default()
+                    },
+                    CardButton { index: i },
+                ))
+                .with_children(|p| {
+                    p.spawn(TextBundle::from_sections([
+                        TextSection::new(
+                            card.name,
+                            TextStyle { font_size: 24.0, color: Color::WHITE, ..default() },
+                        ),
+                        TextSection::new(
+                            format!("\n{}", card.description),
+                            TextStyle { font_size: 16.0, color: Color::WHITE, ..default() },
+                        ),
+                    ]));
+                });
+        });
+    }
+}
+
+pub fn cleanup_card_ui(mut commands: Commands, query: Query<Entity, With<CardUiRoot>>) {
+    for e in &query {
+        commands.entity(e).despawn_recursive();
+    }
+}
+
+pub fn card_click_system(
+    mut interactions: Query<(&Interaction, &CardButton), Changed<Interaction>>,
+    mut next_state: ResMut<NextState<GameState>>,
+    mut selection: ResMut<CardSelection>,
+    mut players: Query<(&Player, &mut Stats, &mut Inventory)>,
+) {
+    for (interaction, button) in &mut interactions {
+        if *interaction == Interaction::Pressed {
+            if let Some(card) = selection.choices.get(button.index) {
+                if let Some(loser) = selection.loser {
+                    for (player, mut stats, mut inv) in players.iter_mut() {
+                        if player.id == loser {
+                            cards::apply(card.id, &mut stats);
+                            inv.cards.push(card.id);
+                        }
+                    }
+                }
+            }
+            selection.loser = None;
+            selection.choices.clear();
+            next_state.set(GameState::InGame);
+            break;
+        }
+    }
+}

--- a/src/systems/game_over.rs
+++ b/src/systems/game_over.rs
@@ -1,0 +1,69 @@
+use bevy::prelude::*;
+
+use crate::components::{Health, Player, Projectile};
+use crate::resources::RoundManager;
+use crate::states::GameState;
+
+#[derive(Component)]
+pub struct GameOverUiRoot;
+
+pub fn setup_game_over(mut commands: Commands, manager: Res<RoundManager>) {
+    let winner = if manager.p1_score > manager.p2_score { 1 } else { 2 };
+    commands
+        .spawn((
+            NodeBundle {
+                style: Style {
+                    width: Val::Percent(100.0),
+                    height: Val::Percent(100.0),
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                background_color: Color::rgba(0.0, 0.0, 0.0, 0.7).into(),
+                ..default()
+            },
+            GameOverUiRoot,
+        ))
+        .with_children(|parent| {
+            parent.spawn(TextBundle::from_section(
+                format!("Game Over! Player {winner} wins. Press R to restart."),
+                TextStyle {
+                    font_size: 32.0,
+                    color: Color::WHITE,
+                    ..default()
+                },
+            ));
+        });
+}
+
+pub fn cleanup_game_over(mut commands: Commands, query: Query<Entity, With<GameOverUiRoot>>) {
+    for e in &query {
+        commands.entity(e).despawn_recursive();
+    }
+}
+
+pub fn game_over_input(
+    keyboard: Res<Input<KeyCode>>,
+    mut next_state: ResMut<NextState<GameState>>,
+    mut manager: ResMut<RoundManager>,
+    mut players: Query<(&Player, &mut Transform, &mut Health)>,
+    projectiles: Query<Entity, With<Projectile>>,
+    mut commands: Commands,
+) {
+    if keyboard.just_pressed(KeyCode::R) {
+        manager.p1_score = 0;
+        manager.p2_score = 0;
+        for entity in &projectiles {
+            commands.entity(entity).despawn();
+        }
+        for (player, mut transform, mut health) in players.iter_mut() {
+            health.current = health.max;
+            transform.translation = if player.id == 1 {
+                Vec3::new(-100.0, 0.0, 0.0)
+            } else {
+                Vec3::new(100.0, 0.0, 0.0)
+            };
+        }
+        next_state.set(GameState::InGame);
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -9,7 +9,12 @@ use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
 mod hud;
+mod card_selection;
+mod game_over;
+
 pub use hud::{setup_hud, update_hud};
+pub use card_selection::{setup_card_ui, cleanup_card_ui, card_click_system};
+pub use game_over::{setup_game_over, cleanup_game_over, game_over_input};
 
 pub fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
@@ -358,11 +363,7 @@ pub fn card_input_system(
     mut next_state: ResMut<NextState<GameState>>,
     mut selection: ResMut<CardSelection>,
     mut players: Query<(&Player, &mut Stats, &mut Inventory)>,
-    state: Res<State<GameState>>,
 ) {
-    if state.get() != &GameState::CardSelection {
-        return;
-    }
     let loser = match selection.loser {
         Some(id) => id,
         None => return,


### PR DESCRIPTION
## Summary
- add UI for card selection and game over phases
- hook systems to game states
- clean up the old card input system

## Testing
- `cargo check -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_686e0221537c8323a3c771c90b30097a