### PR TITLE
Fix starting aim direction and add new aiming controls

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -31,8 +31,8 @@ To build this game, we will use a modern Rust-based game development stack. Belo
 
 - **Input Handling:** Bevy’s input system will let us manage keyboard and gamepad controls. We will support two players:
 
-  - **Player 1:** Keyboard (WASD for movement, **Space** to jump, **Left Ctrl** to shoot, Q/E to aim) or first gamepad.
-  - **Player 2:** Second gamepad (or an alternative key scheme). Bevy assigns unique IDs to each connected gamepad, which we can use to map inputs to specific players. This makes local multiplayer input handling straightforward – we’ll read gamepad events and route them to the appropriate player entity. We will likely create an input mapping resource or use an input plugin (like `leafwing_input_manager`) to define actions (move, jump, shoot, block) and bind them for each player. Ensuring both keyboard and controller can be used will make testing easier (solo developer can control both players with one on keyboard, one on controller).
+  - **Player 1:** Keyboard (A/D to move, **Space** to jump, **Left Ctrl** to shoot, Q/E or W/S to change aim) or first gamepad.
+  - **Player 2:** Second gamepad (or an alternative key scheme). On keyboard use the arrow keys to move/jump, **Return** to shoot and Comma/Period or I/K to change aim. Bevy assigns unique IDs to each connected gamepad, which we can use to map inputs to specific players. This makes local multiplayer input handling straightforward – we’ll read gamepad events and route them to the appropriate player entity. We will likely create an input mapping resource or use an input plugin (like `leafwing_input_manager`) to define actions (move, jump, shoot, block) and bind them for each player. Ensuring both keyboard and controller can be used will make testing easier (solo developer can control both players with one on keyboard, one on controller).
 
 - **Development Tools & Other Libraries:** As a newcomer to the ecosystem, it’s wise to leverage some helper tools:
 

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -49,7 +49,7 @@ pub fn setup(mut commands: Commands) {
             cooldown_timer: 0.0,
             poison_damage: 0.0,
             slow_amount: 0.0,
-            aim_angle: std::f32::consts::FRAC_PI_2,
+            aim_angle: 0.0,
         },
         RigidBody::Dynamic,
         Collider::cuboid(15.0, 15.0),
@@ -81,7 +81,7 @@ pub fn setup(mut commands: Commands) {
             cooldown_timer: 0.0,
             poison_damage: 0.0,
             slow_amount: 0.0,
-            aim_angle: std::f32::consts::FRAC_PI_2,
+            aim_angle: 0.0,
         },
         RigidBody::Dynamic,
         Collider::cuboid(15.0, 15.0),
@@ -112,10 +112,10 @@ pub fn player_input(
                 if keyboard.pressed(KeyCode::D) {
                     direction += 1.0;
                 }
-                if keyboard.pressed(KeyCode::Q) {
+                if keyboard.pressed(KeyCode::Q) || keyboard.pressed(KeyCode::W) {
                     stats.aim_angle += 0.05;
                 }
-                if keyboard.pressed(KeyCode::E) {
+                if keyboard.pressed(KeyCode::E) || keyboard.pressed(KeyCode::S) {
                     stats.aim_angle -= 0.05;
                 }
                 if keyboard.just_pressed(KeyCode::Space) && transform.translation.y <= 16.0 {
@@ -133,10 +133,10 @@ pub fn player_input(
                 if keyboard.pressed(KeyCode::Right) {
                     direction += 1.0;
                 }
-                if keyboard.pressed(KeyCode::Comma) {
+                if keyboard.pressed(KeyCode::Comma) || keyboard.pressed(KeyCode::I) {
                     stats.aim_angle += 0.05;
                 }
-                if keyboard.pressed(KeyCode::Period) {
+                if keyboard.pressed(KeyCode::Period) || keyboard.pressed(KeyCode::K) {
                     stats.aim_angle -= 0.05;
                 }
                 if keyboard.just_pressed(KeyCode::Up) && transform.translation.y <= 16.0 {


### PR DESCRIPTION
## Summary
- start player aim horizontally instead of straight up
- allow player 1 to aim with W/S in addition to Q/E
- allow player 2 to aim with I/K in addition to comma/period
- document the updated controls

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686e9250540c8323b99cefe3520f95fc