### PR TITLE
Fix aim sensitivity and show player in card screen

### DIFF
--- a/src/systems/card_selection.rs
+++ b/src/systems/card_selection.rs
@@ -21,6 +21,7 @@ pub fn setup_card_ui(mut commands: Commands, selection: Res<CardSelection>) {
                 style: Style {
                     width: Val::Percent(100.0),
                     height: Val::Percent(100.0),
+                    flex_direction: FlexDirection::Column,
                     justify_content: JustifyContent::SpaceEvenly,
                     align_items: AlignItems::Center,
                     ..default()
@@ -32,39 +33,78 @@ pub fn setup_card_ui(mut commands: Commands, selection: Res<CardSelection>) {
         ))
         .id();
 
-    for (i, card) in selection.choices.iter().enumerate() {
-        commands.entity(root).with_children(|parent| {
-            parent
-                .spawn((
-                    ButtonBundle {
-                        style: Style {
-                            width: Val::Px(180.0),
-                            height: Val::Px(120.0),
-                            flex_direction: FlexDirection::Column,
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
-                            margin: UiRect::all(Val::Px(5.0)),
-                            ..default()
-                        },
-                        background_color: Color::DARK_GRAY.into(),
+    // Display which player is selecting cards
+    let player_id = selection.loser.unwrap_or(0);
+    commands.entity(root).with_children(|parent| {
+        parent
+            .spawn(NodeBundle {
+                style: Style {
+                    width: Val::Percent(100.0),
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                background_color: Color::NONE.into(),
+                ..default()
+            })
+            .with_children(|p| {
+                p.spawn(TextBundle::from_section(
+                    format!("Player {player_id} - choose a card"),
+                    TextStyle {
+                        font_size: 32.0,
+                        color: Color::WHITE,
                         ..default()
                     },
-                    CardButton { index: i },
-                ))
-                .with_children(|p| {
-                    p.spawn(TextBundle::from_sections([
-                        TextSection::new(
-                            card.name,
-                            TextStyle { font_size: 24.0, color: Color::WHITE, ..default() },
-                        ),
-                        TextSection::new(
-                            format!("\n{}", card.description),
-                            TextStyle { font_size: 16.0, color: Color::WHITE, ..default() },
-                        ),
-                    ]));
-                });
-        });
-    }
+                ));
+            });
+    });
+
+    commands.entity(root).with_children(|parent| {
+        parent
+            .spawn(NodeBundle {
+                style: Style {
+                    width: Val::Percent(100.0),
+                    justify_content: JustifyContent::SpaceEvenly,
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                background_color: Color::NONE.into(),
+                ..default()
+            })
+            .with_children(|row| {
+                for (i, card) in selection.choices.iter().enumerate() {
+                    row
+                        .spawn((
+                            ButtonBundle {
+                                style: Style {
+                                    width: Val::Px(180.0),
+                                    height: Val::Px(120.0),
+                                    flex_direction: FlexDirection::Column,
+                                    justify_content: JustifyContent::Center,
+                                    align_items: AlignItems::Center,
+                                    margin: UiRect::all(Val::Px(5.0)),
+                                    ..default()
+                                },
+                                background_color: Color::DARK_GRAY.into(),
+                                ..default()
+                            },
+                            CardButton { index: i },
+                        ))
+                        .with_children(|p| {
+                            p.spawn(TextBundle::from_sections([
+                                TextSection::new(
+                                    card.name,
+                                    TextStyle { font_size: 24.0, color: Color::WHITE, ..default() },
+                                ),
+                                TextSection::new(
+                                    format!("\n{}", card.description),
+                                    TextStyle { font_size: 16.0, color: Color::WHITE, ..default() },
+                                ),
+                            ]));
+                        });
+                }
+            });
+    });
 }
 
 pub fn cleanup_card_ui(mut commands: Commands, query: Query<Entity, With<CardUiRoot>>) {

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -113,10 +113,10 @@ pub fn player_input(
                     direction += 1.0;
                 }
                 if keyboard.pressed(KeyCode::Q) || keyboard.pressed(KeyCode::W) {
-                    stats.aim_angle += 0.05;
+                    stats.aim_angle += 0.03;
                 }
                 if keyboard.pressed(KeyCode::E) || keyboard.pressed(KeyCode::S) {
-                    stats.aim_angle -= 0.05;
+                    stats.aim_angle -= 0.03;
                 }
                 if keyboard.just_pressed(KeyCode::Space) && transform.translation.y <= 16.0 {
                     velocity.linvel.y = stats.jump_force;
@@ -134,10 +134,10 @@ pub fn player_input(
                     direction += 1.0;
                 }
                 if keyboard.pressed(KeyCode::Comma) || keyboard.pressed(KeyCode::I) {
-                    stats.aim_angle += 0.05;
+                    stats.aim_angle += 0.03;
                 }
                 if keyboard.pressed(KeyCode::Period) || keyboard.pressed(KeyCode::K) {
-                    stats.aim_angle -= 0.05;
+                    stats.aim_angle -= 0.03;
                 }
                 if keyboard.just_pressed(KeyCode::Up) && transform.translation.y <= 16.0 {
                     velocity.linvel.y = stats.jump_force;


### PR DESCRIPTION
## Summary
- reduce aim angle adjustment
- display which player is choosing a card in the card selection UI

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686eab9f01a083239f013433a8267cbd